### PR TITLE
Make the app cross-platform by using Path.Join

### DIFF
--- a/Deployr.Processor/ProcessorTask.cs
+++ b/Deployr.Processor/ProcessorTask.cs
@@ -51,8 +51,8 @@ namespace Deployr.Processor
 		{
 			try
 			{
-				var artifactLocation = $"{deployment.DeploymentLocation}\\artifacts";
-				var artifactFilePath = $"{artifactLocation}\\{deployment.PackageName}-{deployment.Version}.zip";
+				var artifactLocation = Path.Join(deployment.DeploymentLocation, "artifacts");
+				var artifactFilePath = Path.Join(artifactLocation, $"{deployment.PackageName}-{deployment.Version}.zip");
 				// Update database status to unzipping, Unzip artifacts
 				var updateStatusResult = await UpdateDeploymentStatus(deployment.Id, DeploymentStatus.Unzipping);
 				if (!updateStatusResult.WasSuccessful) { /** Log something... once we have a logger */ }

--- a/Deployr.Web/Logic/DeployLogic.cs
+++ b/Deployr.Web/Logic/DeployLogic.cs
@@ -45,7 +45,7 @@ namespace Deployr.Web.Logic
 			var artifactDirectory = CreateArtifactsDirectory(deployLocation);
 
 			var artifactFileName = $"{deploymentInformation.PackageName}-{deploymentInformation.Version}.zip";
-			var artifactFullFileName = $"{artifactDirectory}\\{artifactFileName}";
+			var artifactFullFileName = Path.Join(artifactDirectory.ToString(), artifactFileName);
 			await SaveFileToDiskAsync(file, artifactFullFileName);
 
 			var updateResult = await UpdateDeployment(deploymentId, deployLocation, DeploymentStatus.Ready);
@@ -58,7 +58,7 @@ namespace Deployr.Web.Logic
 
 		public async Task<BasicResponse> CreateDeployment(CreateDeploymentRequest metadata)
 		{
-			using var dataContext = await _dataContextFactory.Construct();
+			await using var dataContext = await _dataContextFactory.Construct();
 			var dataBridge = dataContext.GetDeploymentDataBridge();
 			var result = await dataBridge.CreateDeployment(metadata);
 			return new BasicResponse(result.ToString());
@@ -66,7 +66,7 @@ namespace Deployr.Web.Logic
 
 		public async Task<DeploymentInformation> GetDeploymentInformation(int id)
 		{
-			using var dataContext = await _dataContextFactory.Construct();
+			await using var dataContext = await _dataContextFactory.Construct();
 			var dataBridge = dataContext.GetDeploymentDataBridge();
 			var result = await dataBridge.GetDeploymentMetadata(id);
 			return result;
@@ -74,7 +74,7 @@ namespace Deployr.Web.Logic
 
 		public async Task<bool> UpdateDeployment(int id, string deploymentLocation, DeploymentStatus status)
 		{
-			using var dataContext = await _dataContextFactory.Construct();
+			await using var dataContext = await _dataContextFactory.Construct();
 			var dataBridge = dataContext.GetDeploymentDataBridge();
 			var result = await dataBridge.UpdateDeployment(id, deploymentLocation, status);
 			return result;
@@ -82,7 +82,7 @@ namespace Deployr.Web.Logic
 
 		public async Task<bool> UpdateDeploymentStatus(int id, DeploymentStatus status)
 		{
-			using var dataContext = await _dataContextFactory.Construct();
+			await using var dataContext = await _dataContextFactory.Construct();
 			var dataBridge = dataContext.GetDeploymentDataBridge();
 			var result = await dataBridge.UpdateDeploymentStatus(id, status);
 			return result;
@@ -90,7 +90,7 @@ namespace Deployr.Web.Logic
 
 		private static async Task SaveFileToDiskAsync(IFormFile file, string filePath)
 		{
-			using var fileStream = new FileStream(filePath, FileMode.Create);
+			await using var fileStream = new FileStream(filePath, FileMode.Create);
 			await file.CopyToAsync(fileStream);
 		}
 
@@ -108,7 +108,7 @@ namespace Deployr.Web.Logic
 				throw new WebException(400, "Package already deployed");
 
 			// Delete old artifacts
-			if (directoryExists && forceDeploy)
+			if (directoryExists || forceDeploy)
 				Directory.Delete(deployLocation, true);
 
 			return Directory.CreateDirectory(deployLocation);
@@ -117,20 +117,24 @@ namespace Deployr.Web.Logic
 
 		private static string GetDeployLocation(string packageName, string version)
 		{
-			return $"{DetermineDefaultDeployLocation()}\\{packageName}-{version}";
+			return Path.Join(DetermineDefaultDeployLocation(), $"{packageName}-{version}");
 		}
 
 		private static string DetermineDefaultDeployLocation()
 		{
 			const string windowsDefaultDeployLocation = "C:\\CustomApps";
+			const string linuxDefaultDeployLocation = "~/CustomApps";
+			
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				return windowsDefaultDeployLocation;
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+				return linuxDefaultDeployLocation;
 			throw new WebException(500, "Unsupported platform");
 		}
 
 		public async Task<IEnumerable<DeploymentInformation>> GetDeploymentsAsync(IEnumerable<DeploymentStatus> deploymentStatuses)
 		{
-			using var dataContext = await _dataContextFactory.Construct();
+			await using var dataContext = await _dataContextFactory.Construct();
 			var dataBridge = dataContext.GetDeploymentDataBridge();
 			var result = await dataBridge.GetDeploymentsAsync(deploymentStatuses);
 			return result;

--- a/Deployr.Web/Logic/DeployLogic.cs
+++ b/Deployr.Web/Logic/DeployLogic.cs
@@ -108,7 +108,7 @@ namespace Deployr.Web.Logic
 				throw new WebException(400, "Package already deployed");
 
 			// Delete old artifacts
-			if (directoryExists || forceDeploy)
+			if (directoryExists)
 				Directory.Delete(deployLocation, true);
 
 			return Directory.CreateDirectory(deployLocation);
@@ -123,7 +123,7 @@ namespace Deployr.Web.Logic
 		private static string DetermineDefaultDeployLocation()
 		{
 			const string windowsDefaultDeployLocation = "C:\\CustomApps";
-			const string linuxDefaultDeployLocation = "~/CustomApps";
+			const string linuxDefaultDeployLocation = "/usr/local/bin/CustomApps";
 			
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				return windowsDefaultDeployLocation;


### PR DESCRIPTION
- Fixed login bug by using OR instead of AND (probably a logic bug)
- Used `await using` instead of `using` which is a new C# feature
- Added support for Linux and Mac by using cross-platform `Path.Join` as oppose to string interpolation 
