### PR TITLE
Redesigned background task to be long-running and added logger

### DIFF
--- a/Deployr.Processor/BackgroundDeployrTask.cs
+++ b/Deployr.Processor/BackgroundDeployrTask.cs
@@ -37,7 +37,7 @@ namespace Deployr.Processor
                 {
                     logger.LogTrace("Starting to run listener task");
 
-                    processorTask.Process();
+                    processorTask.Process().Wait();
 
                     logger.LogTrace("Finished running listener task");
 

--- a/Deployr.Processor/BackgroundDeployrTask.cs
+++ b/Deployr.Processor/BackgroundDeployrTask.cs
@@ -1,0 +1,53 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Deployr.Processor
+{
+    /// <summary>
+    /// Defines the long-running background task and cancellation token
+    /// </summary>
+    public interface IBackgroundDeployrTask
+    {
+        CancellationTokenSource CancellationToken { get; }
+
+        Task ListenerTask { get; }
+    }
+
+    public class BackgroundDeployrTask : IBackgroundDeployrTask
+    {
+        /// <summary>
+        /// Wait period in Millisecond
+        /// </summary>
+        private const int WaitMillisecond = 5000;
+
+        public CancellationTokenSource CancellationToken { get; }
+
+        public Task ListenerTask { get; }
+
+        public BackgroundDeployrTask(IProcessorTask processorTask, ILogger<BackgroundDeployrTask> logger)
+        {
+            CancellationToken = new CancellationTokenSource();
+
+            var token = CancellationToken.Token;
+
+            ListenerTask = Task.Factory.StartNew(_ =>
+            {
+                while (!CancellationToken.IsCancellationRequested)
+                {
+                    logger.LogTrace("Starting to run listener task");
+
+                    processorTask.Process();
+
+                    logger.LogTrace("Finished running listener task");
+
+                    logger.LogTrace($"Starting to wait {WaitMillisecond}ms before the next run");
+                    
+                    Thread.Sleep(WaitMillisecond);
+
+                    logger.LogTrace($"Finished Waiting {WaitMillisecond}ms for the next run");
+                }
+            }, null, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+    }
+}

--- a/Deployr.Processor/Deployr.Processor.csproj
+++ b/Deployr.Processor/Deployr.Processor.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>

--- a/Deployr.Processor/Program.cs
+++ b/Deployr.Processor/Program.cs
@@ -26,7 +26,7 @@ namespace Deployr.Processor
             }
             finally
             {
-                backgroundDeployrTask.CancellationToken.Cancel();
+                backgroundDeployrTask.CancellationTokenSource.Cancel();
             }
         }
 

--- a/Deployr.Processor/Program.cs
+++ b/Deployr.Processor/Program.cs
@@ -2,43 +2,52 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Deployr.Processor
 {
-	class Program
-	{
-		static async Task Main()
-		{
-			var serviceProvider = BuildServiceProvider();
+    class Program
+    {
+        static async Task Main()
+        {
+            var serviceProvider = BuildServiceProvider();
+            var logger = serviceProvider.GetService<ILogger>();
+            var backgroundDeployrTask = serviceProvider.GetService<IBackgroundDeployrTask>();
 
-			var processTask = serviceProvider.GetRequiredService<IProcessorTask>();
+            try
+            {
+                await backgroundDeployrTask.ListenerTask;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed running background task");
+            }
+            finally
+            {
+                backgroundDeployrTask.CancellationToken.Cancel();
+            }
+        }
 
-			while (true) 
-			{
-				await processTask.Process();
+        private static IServiceProvider BuildServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddLogging(cfg => cfg.AddConsole())
+                .Configure<LoggerFilterOptions>(cfg => cfg.MinLevel = LogLevel.Trace);
 
-				// Sleep for 5 seconds
-				Thread.Sleep(5000);
-			}
-		}
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", false)
+                .Build();
 
-		private static IServiceProvider BuildServiceProvider()
-		{
-			var serviceCollection = new ServiceCollection();
-			var configuration = new ConfigurationBuilder()
-				.SetBasePath(Directory.GetCurrentDirectory())
-				.AddJsonFile("appsettings.json", false)
-				.Build();
+            // TODO: Setup/add logger
+            serviceCollection.AddSingleton<IConfiguration>(configuration);
+            serviceCollection.AddSingleton<AppSettings>();
+            serviceCollection.AddSingleton<IBackgroundDeployrTask, BackgroundDeployrTask>();
+            serviceCollection.AddTransient<IProcessorTask, ProcessorTask>();
 
-			// TODO: Setup/add logger
-			serviceCollection.AddSingleton<IConfiguration>(configuration);
-			serviceCollection.AddSingleton<AppSettings>();
-			serviceCollection.AddTransient<IProcessorTask, ProcessorTask>();
-			return serviceCollection.BuildServiceProvider();
-		}
-	}
+            return serviceCollection.BuildServiceProvider();
+        }
+    }
 }

--- a/Deployr.Web/Properties/launchSettings.json
+++ b/Deployr.Web/Properties/launchSettings.json
@@ -1,26 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:64698",
-      "sslPort": 44306
-    }
-  },
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "docs",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Deployr": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchUrl": "Deployr.Web",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
- It's very important to use `TaskCreationOptions.LongRunning` if the task is long-running. This will schedule garbage collector differently and optimize memory allocation for long-running.
- `CancellationToken` to signal task to stop
- Added console logger as well.